### PR TITLE
Bugfixes:

### DIFF
--- a/src/Validator/ValidationResult.php
+++ b/src/Validator/ValidationResult.php
@@ -65,8 +65,8 @@ final class ValidationResult implements ValidationResultInterface
         $messages = [];
 
         if (! $inputFilter->isValid()) {
-            foreach ($inputFilter->getInvalidInput() as $message) {
-                $messages[$message->getName()] = $message->getMessages();
+            foreach ($inputFilter->getInvalidInput() as $name => $message) {
+                $messages[$name] = $message->getMessages();
             }
         }
         // Return validation result

--- a/src/Validator/ValidatorHandler.php
+++ b/src/Validator/ValidatorHandler.php
@@ -122,6 +122,6 @@ class ValidatorHandler implements ValidatorInterface
             );
         }
 
-        return $this->inputFilterManager->get($inputFilterService);
+        return $inputFilter;
     }
 }

--- a/test/Extractor/DataExtractorChainTest.php
+++ b/test/Extractor/DataExtractorChainTest.php
@@ -13,6 +13,7 @@ namespace ZETest\ContentValidation\Extractor;
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use ZE\ContentValidation\Extractor\BodyExtractor;
 use ZE\ContentValidation\Extractor\DataExtractorChain;
@@ -269,17 +270,17 @@ class DataExtractorChainTest extends TestCase
                 'name' => '/tmp/12345678adf',
                 'type' => 'text/plain',
                 'size' => '10',
-                'error' => null
+                'error' => 0
             ]
         ];
 
         $uploadedFile = $this->prophesize(UploadedFile::class);
 
-        $uploadedFile->getStream()->willReturn('');
+        $uploadedFile->getStream()->willReturn($this->prophesize(StreamInterface::class));
         $uploadedFile->getClientFilename()->willReturn('/tmp/12345678adf');
         $uploadedFile->getClientMediaType()->willReturn('text/plain');
         $uploadedFile->getSize()->willReturn('10');
-        $uploadedFile->getError()->willReturn(null);
+        $uploadedFile->getError()->willReturn(0);
 
         $request = ServerRequestFactory::fromGlobals()
             ->withMethod('POST')


### PR DESCRIPTION
 1. https://github.com/mvlabs/ze-content-validation/issues/15 (input filter created twice)
 2. $inputFilter->getInvalidInput() can return instance of InputFilterInterface, which doesn't implement getName()