### PR TITLE
[fix-validation-result] Fix validation result if nested input filters…

### DIFF
--- a/src/Validator/ValidationResult.php
+++ b/src/Validator/ValidationResult.php
@@ -65,8 +65,8 @@ final class ValidationResult implements ValidationResultInterface
         $messages = [];
 
         if (! $inputFilter->isValid()) {
-            foreach ($inputFilter->getInvalidInput() as $message) {
-                $messages[$message->getName()] = $message->getMessages();
+            foreach ($inputFilter->getInvalidInput() as $name => $message) {
+                $messages[$name] = $message->getMessages();
             }
         }
         // Return validation result


### PR DESCRIPTION
… get provided

When i was using an InputFilter with a nested CollectionInputFilter i saw that this ValidationResult tries to use CollectionFilter::getName, which causes an error because the property $invalidInputs of the CollectionInputFilter can also return InputFilterInterface[]

```php
/**
 * @var InputInterface[]|InputFilterInterface[]
 */
protected $invalidInputs;
```

however this ValidationResult only works if you get InputInterface[]. 
fortunately the index variable of this foreach always contains the name that is needed for this ValidationResult.

the interfaces dont seem to fit together perfectly, see https://github.com/laminas/laminas-inputfilter/issues/22 by func0der